### PR TITLE
Fix compiler warnings for deprecated calendar components

### DIFF
--- a/Library/Printers/NWLTools.m
+++ b/Library/Printers/NWLTools.m
@@ -35,7 +35,7 @@
     dispatch_once(&onceToken, ^{
         calendar = NSCalendar.currentCalendar;
     });
-    NSDateComponents *components = [calendar components:(NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit) fromDate:date];
+    NSDateComponents *components = [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond) fromDate:date];
     int hour = (int)[components hour];
     int minute = (int)[components minute];
     int second = (int)[components second];


### PR DESCRIPTION
NSHourCalendarUnit, etc. have been deprecated and replaced with NSCalendarUnit enum values.

_Note: this change makes NWLogging require iOS 7+ headers._
